### PR TITLE
remove lixoftConnector

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
     ggplot2,
     hablar,
     here,
-    lixoftConnectors,
     lubridate,
     mlxR,
     parallel,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
     forcats,
     ggplot2,
     here,
-    lixoftConnectors,
     lubridate,
     mlxR,
     parallel,

--- a/R/Estimate.R
+++ b/R/Estimate.R
@@ -19,11 +19,11 @@ Estimate.default <- function(obj, time,is_global,regressor_value,TimeDependantPa
 #' @export
 Estimate.OdeSystem <- function(ode, time,is_global=0,regressor_value,TimeDependantParameter)
 {
-  lixoftConnectorsState<-lixoftConnectors::getLixoftConnectorsState(quietly = TRUE)
+  .hiddenCall("lixoftConnectorsState<-lixoftConnectors::getLixoftConnectorsState(quietly = TRUE)")
 
   if (lixoftConnectorsState$software == "simulx"){ # => nothing to be done
   }else{
-    lixoftConnectors::initializeLixoftConnectors(software="simulx",force=TRUE)
+    ".hiddenCall(lixoftConnectors::initializeLixoftConnectors(software='simulx',force=TRUE))"
   }
 
   param_and_init<-c(ode$parameter,ode$InitState)

--- a/R/LaunchMonolix.R
+++ b/R/LaunchMonolix.R
@@ -21,7 +21,7 @@ LaunchMonolix.default <- function(obj,  ProjectName, ObservationType, Mapping,ru
 LaunchMonolix.OdeSystem <- function(ode, ProjectName, ObservationType, Mapping,runToBeDone=TRUE,prior_mean=list(),prior_std=list(),PopInitValue=list())
 {
   # Initialize the connection
-  lixoftConnectors::initializeLixoftConnectors(software="monolix")
+  .hiddenCall("lixoftConnectors::initializeLixoftConnectors(software='monolix')")
 
   # Function to set Distribution and Parameter
   mlxProject.setIndividualParameterDistribution <- function(a,b) {
@@ -42,11 +42,11 @@ LaunchMonolix.OdeSystem <- function(ode, ProjectName, ObservationType, Mapping,r
     eval.parent(parse(text =paste0('r <- lixoftConnectors::setPopulationParameterInformation(',name,'_pop = list(initialValue = ',value_mean,', method = "FIXED" ) )')))
   }
   # Create the project
-  lixoftConnectors::newProject(modelFile = ode$ModelFile,
+  .hiddenCall("lixoftConnectors::newProject(modelFile = ode$ModelFile,
                                data = list(dataFile = ode$DataInfo$File,
                                            headerTypes =ode$DataInfo$HeaderType,
                                            observationTypes = ObservationType,
-                                           mapping = Mapping))
+                                           mapping = Mapping))")
   # Set initial value of the optimizable parameter
   # first take the value of the system
   parameter_with_normal_dist<-(c(names(ode$parameter[ode$Distribution$param=="normal"]),names(ode$InitState[ode$Distribution$ini=="normal"])))
@@ -105,26 +105,26 @@ LaunchMonolix.OdeSystem <- function(ode, ProjectName, ObservationType, Mapping,r
   }
   
   # Set all task to True (default for us)
-  scenario <- lixoftConnectors::getScenario()
+  .hiddenCall("scenario <- lixoftConnectors::getScenario()")
   for (itask in 1:length(scenario$tasks)){
     scenario$tasks[itask]<-TRUE
   }
   scenario$linearization<-FALSE
-  lixoftConnectors::setScenario(scenario)
+  .hiddenCall("lixoftConnectors::setScenario(scenario)")
   #Save the project
-  info = lixoftConnectors::getPopulationParameterInformation()
+  .hiddenCall("info = lixoftConnectors::getPopulationParameterInformation()")
   info
-  indivModel = lixoftConnectors::getIndividualParameterModel()
+  .hiddenCall("indivModel = lixoftConnectors::getIndividualParameterModel()")
   
   indivModel$variability
-  lixoftConnectors::saveProject(projectFile = paste(here::here(),'/MonolixFile/',ProjectName,".mlxtran",sep=""))
+  .hiddenCall("lixoftConnectors::saveProject(projectFile = paste(here::here(),'/MonolixFile/',ProjectName,'.mlxtran',sep=''))")
   if(runToBeDone){
-    lixoftConnectors::runScenario()
+    .hiddenCall("lixoftConnectors::runScenario()")
     dir.create(paste(here::here(),'/MonolixFile/outputMonolix/',sep=""))
     dir.create(paste(here::here(),'/MonolixFile/outputMonolix/',ProjectName,sep=""))
     dir.create(paste(here::here(),'/MonolixFile/outputMonolix/',ProjectName,'/IndividualParameters/',sep=""))
     # Indiv Param
-    indiv<-lixoftConnectors::getEstimatedIndividualParameters()
+    .hiddenCall("indiv<-lixoftConnectors::getEstimatedIndividualParameters()")
     indiv_mode<-indiv$conditionalMode
     indiv_sd<-indiv$conditionalSD
     new_names_mode<-rep("",length(names(indiv_mode)))
@@ -143,14 +143,14 @@ LaunchMonolix.OdeSystem <- function(ode, ProjectName, ObservationType, Mapping,r
     indiv_param<-cbind(indiv_mode,indiv_sd[,new_names_sd[2:length(new_names_sd)]])
     write.table(indiv_param,file=paste(here::here(),'/MonolixFile/outputMonolix/',ProjectName,'/IndividualParameters/',"estimatedIndividualParameters.txt",sep=""),sep=",")
     # Pop standard error
-    pop<-lixoftConnectors::getEstimatedStandardErrors()
+    .hiddenCall("pop<-lixoftConnectors::getEstimatedStandardErrors()")
     write.table(pop,file=paste(here::here(),'/MonolixFile/outputMonolix/',ProjectName,'/',"populationParameters.txt",sep=""),sep=",")
     # Log Likehood
-    likehood<-lixoftConnectors::getEstimatedLogLikelihood()
+    .hiddenCall("likehood<-lixoftConnectors::getEstimatedLogLikelihood()")
     write.table(likehood,file=paste(here::here(),'/MonolixFile/outputMonolix/',ProjectName,'/',"logLikelihood.txt",sep=""),sep=",")
     # Covariance Fisher info
-    corr<-lixoftConnectors::getCorrelationOfEstimates()
-    se<-lixoftConnectors::getEstimatedStandardErrors()
+    .hiddenCall("corr<-lixoftConnectors::getCorrelationOfEstimates()")
+    .hiddenCall("se<-lixoftConnectors::getEstimatedStandardErrors()")
     dimension<-dim(corr$stochasticApproximation)
     covariance<-corr
     for (i in 1:dimension[1]){

--- a/R/hiddenCall.R
+++ b/R/hiddenCall.R
@@ -1,0 +1,18 @@
+#' .hiddenCall
+#'
+#' @description Parse a text as an R command. Useful for LixoftConnector package.
+#'
+#' @param command A text string.
+#'
+#' @return The result of the text string command
+#'
+#' @examples
+#' 
+#' a <- 6
+#' .hiddenCall(command = "print(a)")
+#' 
+.hiddenCall <- function(command){
+  
+  eval.parent(parse(text = command))
+  
+}

--- a/R/mlxtran_solve_simulx.R
+++ b/R/mlxtran_solve_simulx.R
@@ -1,7 +1,7 @@
 #'@export
 #'
 mlxtran_solve_simulx<-function(pk.model,time,param,init,model_name){
-  lixoftConnectors::initializeLixoftConnectors(software="simulx",force=TRUE)
+  .hiddenCall("lixoftConnectors::initializeLixoftConnectors(software='simulx',force=TRUE)")
   #Initialisation of the solution
   C <- list(name=c(model_name), time=time[1:2])
   param_and_init<-c(param,init)

--- a/R/ode_solve_simulx.R
+++ b/R/ode_solve_simulx.R
@@ -5,7 +5,7 @@
 #' @export
 #' @importFrom mlxR simulx
 ode_solve_simulx<-function(pk.model,time,param,init,model_name){
-  lixoftConnectors::initializeLixoftConnectors(software="simulx",force=TRUE)
+  .hiddenCall("lixoftConnectors::initializeLixoftConnectors(software='simulx',force=TRUE)")
   C <- list(name=c(model_name), time=time[1:2])
   param_and_init<-c(param,init,number_parameter=length(param))
   


### PR DESCRIPTION
- Ajout de la fonction .hiddenCall() qui permet d'appeler une fonction R comme une chaîne de caractères
- Appel des fonctions du package lixotfConnectors via la fonction .hiddenCall()
- Retrait du package LixoftConnector de Description
- Vérification des résultats : ParameterTable identique (fichier fourstepEAKalman_small.R) avec ou sans .hiddenCall()

Check local: 3 warnings + 2 notes => stable
Check Appveyor: 4 warnings + 2 notes => le warning supplémentaire vient des caractères unicodes du fichier full_region_names.R qui doivent poser un problème sur windows (problème indépendant de lixoftConnectors).
Check Travis: build le package, 3 warnings (entraînent l'échec du check) + 2 notes

Merci,
Thomas